### PR TITLE
Add VLM toxicity superposition analysis toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# toy-models-of-superposition
-Notebooks accompanying Anthropic's "Toy Models of Superposition" paper
+# VLM Toxicity Superposition Analysis
+
+This project provides a research toolkit for investigating the hypothesis that toxic features are superposed with benign concepts within the latent space of vision-language models (VLMs).
+
+## Project Structure
+
+```
+configs/                  # Experiment configuration files
+  base_config.yaml
+data/                     # Example JSONL datasets used for experiments
+  toxic_neutral_pairs.jsonl
+  multimodal_test_cases.jsonl
+notebooks/
+  analysis.ipynb          # Notebook for exploratory analysis
+scripts/                  # Command line scripts for experiments
+  01_extract_direction.py
+  02_analyze_superposition.py
+  03_evaluate_intervention.py
+src/                      # Core source code
+  vlm_wrapper.py
+  feature_extractor.py
+  analysis.py
+  interventions.py
+requirements.txt          # Python dependencies
+```
+
+## Usage
+
+1. **Extract direction vector**
+   ```bash
+   python scripts/01_extract_direction.py --config configs/base_config.yaml
+   ```
+2. **Analyze superposition**
+   ```bash
+   python scripts/02_analyze_superposition.py --config configs/base_config.yaml
+   ```
+3. **Evaluate interventions**
+   ```bash
+   python scripts/03_evaluate_intervention.py --config configs/base_config.yaml
+   ```
+
+All scripts expect the model specified in the configuration to be available through the Hugging Face `transformers` library.
+
+### Hugging Face models and datasets
+
+- **Models:** set `model_name` in the config to any Hugging Face VLM ID (e.g. `llava-hf/llava-1.5-7b-hf`).
+  Additional arguments for `from_pretrained` may be supplied via `model_kwargs` in the config and will be forwarded by `VLMWrapper`.
+- **Datasets:** entries under `data_sources` accept either local JSONL paths or Hugging Face dataset identifiers
+  (optionally suffixed with `:split`).
+  When a dataset ID is provided, the requisite data will be downloaded automatically using the `datasets` library.

--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -1,0 +1,15 @@
+model_name: "llava-hf/llava-1.5-7b-hf"
+device: "cuda"
+
+# optional arguments passed to `from_pretrained`
+model_kwargs: {}
+
+extraction_layer: "model.layers.30"
+data_sources:
+  toxic_neutral_pairs: "data/toxic_neutral_pairs.jsonl"  # or "user/dataset:split"
+  multimodal_test_cases: "data/multimodal_test_cases.jsonl"  # or "user/dataset:split"
+
+intervention_layer: "model.layers.30"
+intervention_multiplier: 1.2
+
+output_dir: "results/"

--- a/data/multimodal_test_cases.jsonl
+++ b/data/multimodal_test_cases.jsonl
@@ -1,0 +1,2 @@
+{"prompt": "Describe the scene", "image_path": "images/sample1.jpg", "category": "general"}
+{"prompt": "What does the sign say?", "image_path": "images/sample2.jpg", "category": "text"}

--- a/data/toxic_neutral_pairs.jsonl
+++ b/data/toxic_neutral_pairs.jsonl
@@ -1,0 +1,2 @@
+{"toxic": "You are dumb", "neutral": "You are smart"}
+{"toxic": "Nobody likes you", "neutral": "Everybody likes you"}

--- a/notebooks/analysis.ipynb
+++ b/notebooks/analysis.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+torch
+transformers
+pillow
+pandas
+pyyaml
+matplotlib
+plotly
+datasets

--- a/scripts/01_extract_direction.py
+++ b/scripts/01_extract_direction.py
@@ -1,0 +1,28 @@
+import yaml
+import torch
+from pathlib import Path
+from src.vlm_wrapper import VLMWrapper
+from src.feature_extractor import FeatureExtractor
+from src.data_utils import load_pairs
+
+def main(config_path: str):
+    with open(config_path, 'r') as f:
+        cfg = yaml.safe_load(f)
+
+    wrapper = VLMWrapper(cfg['model_name'], cfg['device'], **cfg.get('model_kwargs', {}))
+    extractor = FeatureExtractor(wrapper)
+
+    data_source = cfg['data_sources']['toxic_neutral_pairs']
+    toxic_prompts, neutral_prompts = load_pairs(data_source)
+    direction = extractor.compute_direction_vector(toxic_prompts, neutral_prompts, cfg['extraction_layer'])
+
+    output_dir = Path(cfg.get('output_dir', 'results'))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    torch.save(direction, output_dir / 'direction_vector.pt')
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', default='configs/base_config.yaml')
+    args = parser.parse_args()
+    main(args.config)

--- a/scripts/02_analyze_superposition.py
+++ b/scripts/02_analyze_superposition.py
@@ -1,0 +1,34 @@
+import yaml
+import torch
+import pandas as pd
+from pathlib import Path
+from src.vlm_wrapper import VLMWrapper
+from src.analysis import analyze_concept_overlap, analyze_cross_modal_amplification
+from src.data_utils import load_cases
+
+def main(config_path: str):
+    with open(config_path, 'r') as f:
+        cfg = yaml.safe_load(f)
+
+    wrapper = VLMWrapper(cfg['model_name'], cfg['device'], **cfg.get('model_kwargs', {}))
+
+    direction = torch.load(Path(cfg.get('output_dir', 'results')) / 'direction_vector.pt')
+
+    cases = load_cases(cfg['data_sources']['multimodal_test_cases'])
+
+    prompts = [c['prompt'] for c in cases]
+    concept_df = analyze_concept_overlap(wrapper, prompts, cfg['extraction_layer'], direction)
+
+    amp_df = analyze_cross_modal_amplification(wrapper, cases, cfg['extraction_layer'], direction)
+
+    out_dir = Path(cfg.get('output_dir', 'results'))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    concept_df.to_csv(out_dir / 'concept_overlap.csv', index=False)
+    amp_df.to_csv(out_dir / 'cross_modal_amplification.csv', index=False)
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', default='configs/base_config.yaml')
+    args = parser.parse_args()
+    main(args.config)

--- a/scripts/03_evaluate_intervention.py
+++ b/scripts/03_evaluate_intervention.py
@@ -1,0 +1,49 @@
+import json
+import yaml
+import torch
+from pathlib import Path
+from transformers import pipeline
+from src.vlm_wrapper import VLMWrapper
+from src import interventions
+from src.data_utils import load_cases
+
+def main(config_path: str):
+    with open(config_path, 'r') as f:
+        cfg = yaml.safe_load(f)
+
+    wrapper = VLMWrapper(cfg['model_name'], cfg['device'], **cfg.get('model_kwargs', {}))
+    direction = torch.load(Path(cfg.get('output_dir', 'results')) / 'direction_vector.pt')
+
+    cases = load_cases(cfg['data_sources']['multimodal_test_cases'])
+
+    classifier = pipeline('text-classification', model='unitary/unbiased-toxic-roberta')
+
+    records = []
+    for case in cases:
+        prompt = case['prompt']
+        image = case.get('image')
+        normal = wrapper.generate_with_intervention(prompt, cfg['intervention_layer'], lambda x: x, image=image)
+        def fn(act):
+            return interventions.activation_subtraction(act, direction, cfg['intervention_multiplier'])
+        intervened = wrapper.generate_with_intervention(prompt, cfg['intervention_layer'], fn, image=image)
+        score_normal = classifier(normal)[0]['score']
+        score_intervened = classifier(intervened)[0]['score']
+        records.append({
+            'prompt': prompt,
+            'normal_output': normal,
+            'intervened_output': intervened,
+            'normal_score': score_normal,
+            'intervened_score': score_intervened
+        })
+
+    out_dir = Path(cfg.get('output_dir', 'results'))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / 'intervention_evaluation.json', 'w') as f:
+        json.dump(records, f, indent=2)
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', default='configs/base_config.yaml')
+    args = parser.parse_args()
+    main(args.config)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+from .feature_extractor import FeatureExtractor
+from .vlm_wrapper import VLMWrapper
+from .data_utils import load_pairs, load_cases

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -1,0 +1,31 @@
+from typing import List, Dict
+import torch
+import pandas as pd
+from .vlm_wrapper import VLMWrapper
+
+
+def _cosine_similarity(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return torch.nn.functional.cosine_similarity(a, b, dim=-1)
+
+
+def analyze_concept_overlap(wrapper: VLMWrapper, prompts: List[str], layer: str, direction: torch.Tensor) -> pd.DataFrame:
+    acts = wrapper.get_activations(prompts, [layer])[layer]
+    sims = _cosine_similarity(acts, direction)
+    return pd.DataFrame({"prompt": prompts, "cosine_similarity": sims.cpu().tolist()})
+
+
+def analyze_cross_modal_amplification(wrapper: VLMWrapper, cases: List[Dict], layer: str, direction: torch.Tensor) -> pd.DataFrame:
+    records = []
+    for case in cases:
+        text = case["prompt"]
+        image = case.get("image")
+        act_text = wrapper.get_activations([text], [layer])[layer][0]
+        act_multi = wrapper.get_activations([text], [layer], image=image)[layer][0]
+        sim_text = _cosine_similarity(act_text, direction)
+        sim_multi = _cosine_similarity(act_multi, direction)
+        records.append({
+            "prompt": text,
+            "text_only": sim_text.item(),
+            "image_text": sim_multi.item()
+        })
+    return pd.DataFrame(records)

--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+from typing import List, Tuple, Dict, Any
+from pathlib import Path
+import json
+from datasets import load_dataset
+from PIL import Image
+
+
+def load_pairs(source: str) -> Tuple[List[str], List[str]]:
+    """Load paired toxic/neutral prompts from a local file or HF dataset.
+
+    The ``source`` argument accepts either a path to a JSONL file with
+    ``{"toxic": ..., "neutral": ...}`` entries or a Hugging Face dataset
+    identifier optionally suffixed with ``:split``.
+    """
+    path = Path(source)
+    toxic: List[str] = []
+    neutral: List[str] = []
+    if path.exists():
+        with path.open("r") as f:
+            for line in f:
+                item = json.loads(line)
+                toxic.append(item["toxic"])
+                neutral.append(item["neutral"])
+        return toxic, neutral
+
+    if ":" in source:
+        dataset_name, split = source.split(":", 1)
+    else:
+        dataset_name, split = source, "train"
+    ds = load_dataset(dataset_name, split=split)
+    for ex in ds:
+        toxic.append(ex["toxic"])
+        neutral.append(ex["neutral"])
+    return toxic, neutral
+
+
+def load_cases(source: str) -> List[Dict[str, Any]]:
+    """Load multimodal test cases from a JSONL file or HF dataset.
+
+    Each returned dict will contain at least a ``prompt`` key and optional
+    ``image`` entry containing a :class:`PIL.Image.Image`.
+    """
+    path = Path(source)
+    cases: List[Dict[str, Any]] = []
+    if path.exists():
+        with path.open("r") as f:
+            for line in f:
+                item = json.loads(line)
+                img_entry = item.get("image") or item.get("image_path")
+                if isinstance(img_entry, str):
+                    item["image"] = Image.open(img_entry).convert("RGB")
+                else:
+                    item["image"] = img_entry
+                cases.append(item)
+        return cases
+
+    if ":" in source:
+        dataset_name, split = source.split(":", 1)
+    else:
+        dataset_name, split = source, "train"
+    ds = load_dataset(dataset_name, split=split)
+    for ex in ds:
+        item = dict(ex)
+        img_entry = item.get("image") or item.get("image_path")
+        if isinstance(img_entry, str):
+            img_entry = Image.open(img_entry).convert("RGB")
+        item["image"] = img_entry
+        cases.append(item)
+    return cases

--- a/src/feature_extractor.py
+++ b/src/feature_extractor.py
@@ -1,0 +1,15 @@
+from typing import List
+import torch
+from .vlm_wrapper import VLMWrapper
+
+class FeatureExtractor:
+    def __init__(self, wrapper: VLMWrapper) -> None:
+        self.wrapper = wrapper
+
+    def compute_direction_vector(self, toxic_prompts: List[str], neutral_prompts: List[str], layer: str) -> torch.Tensor:
+        toxic_acts = self.wrapper.get_activations(toxic_prompts, [layer])[layer]
+        neutral_acts = self.wrapper.get_activations(neutral_prompts, [layer])[layer]
+        diffs = toxic_acts - neutral_acts
+        direction = diffs.mean(dim=0)
+        direction = direction / direction.norm()
+        return direction

--- a/src/interventions.py
+++ b/src/interventions.py
@@ -1,0 +1,5 @@
+import torch
+
+def activation_subtraction(activation: torch.Tensor, direction: torch.Tensor, multiplier: float = 1.0) -> torch.Tensor:
+    projection = (activation @ direction) / (direction @ direction) * direction
+    return activation - multiplier * projection

--- a/src/vlm_wrapper.py
+++ b/src/vlm_wrapper.py
@@ -1,0 +1,67 @@
+from typing import List, Callable, Dict, Optional
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, AutoProcessor
+
+class VLMWrapper:
+    """Wrapper providing standardized access to VLM internals."""
+
+    def __init__(self, model_name: str, device: str, **model_kwargs) -> None:
+        """Load a pretrained VLM model and associated processors.
+
+        Parameters
+        ----------
+        model_name: str
+            Hugging Face model identifier.
+        device: str
+            Device mapping for model weights.
+        model_kwargs: dict
+            Additional keyword arguments forwarded to
+            :func:`~transformers.AutoModelForCausalLM.from_pretrained`.
+        """
+
+        self.device = device
+        model_kwargs.setdefault("trust_remote_code", True)
+        self.model = AutoModelForCausalLM.from_pretrained(model_name, **model_kwargs).to(device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=model_kwargs["trust_remote_code"])
+        try:
+            self.processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=model_kwargs["trust_remote_code"])
+        except Exception:
+            self.processor = None
+
+    def _prepare_inputs(self, prompts: List[str], image=None) -> Dict[str, torch.Tensor]:
+        inputs = self.tokenizer(prompts, return_tensors="pt", padding=True).to(self.device)
+        if image is not None and self.processor is not None:
+            processed = self.processor(images=image, return_tensors="pt").to(self.device)
+            inputs.update(processed)
+        return inputs
+
+    def get_activations(self, prompts: List[str], layers: List[str], image=None) -> Dict[str, torch.Tensor]:
+        activations: Dict[str, torch.Tensor] = {}
+        handles = []
+        for layer_name in layers:
+            module = self.model.get_submodule(layer_name)
+            def hook(module, inp, output, name=layer_name):
+                activations[name] = output.detach().cpu()
+            handles.append(module.register_forward_hook(hook))
+
+        inputs = self._prepare_inputs(prompts, image)
+        with torch.no_grad():
+            self.model(**inputs)
+        for h in handles:
+            h.remove()
+        return activations
+
+    def generate_with_intervention(self, prompt: str, layer: str, intervention_fn: Callable[[torch.Tensor], torch.Tensor], image=None) -> str:
+        module = self.model.get_submodule(layer)
+
+        def hook(module, inp, output):
+            return intervention_fn(output)
+
+        handle = module.register_forward_hook(hook)
+
+        inputs = self._prepare_inputs([prompt], image)
+        with torch.no_grad():
+            generated = self.model.generate(**inputs)
+        handle.remove()
+        text = self.tokenizer.decode(generated[0], skip_special_tokens=True)
+        return text


### PR DESCRIPTION
## Summary
- implement VLMWrapper for accessing and intervening on model activations
- add feature extraction, analysis, and intervention utilities
- provide experiment scripts and configuration for toxicity direction studies
- enhance scripts and wrapper to download Hugging Face models/datasets

## Testing
- `python -m py_compile $(find . -name "*.py" -print)`

------
https://chatgpt.com/codex/tasks/task_e_68981a2b5cf08320a6c55457e64cab97