### PR TITLE
feat(wrapper): LLaVA (SigLIP+Qwen2) compatibility and generic VLM improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]
+*.so
+
+# Test & tool caches
+.pytest_cache/
+.ipynb_checkpoints/
+
+# OS / Editor
+.DS_Store
+*.swp
+
+# Environments
+.env
+.venv/
+
+# Logs
+*.log
+
+# Data artifacts (optional)
+# data/**/*.tmp

--- a/src/vlm_wrapper.py
+++ b/src/vlm_wrapper.py
@@ -1,16 +1,22 @@
 """Utilities for accessing and intervening on pretrained VLMs.
 
 This module provides a :class:`VLM_Wrapper` class that loads a
-Hugging Face vision-language model and exposes helper methods for
+Hugging Face vision–language model and exposes helper methods for
 extracting internal activations and performing interventions during
-generation.  The implementation follows the design laid out in the
-development specification, using PyTorch forward hooks to record or
-modify activations at arbitrary layers.
+generation. It is designed to work out-of-the-box with LLaVA-style
+models (e.g., LlavaForConditionalGeneration with SigLIP vision tower
+and Qwen2 language model) while remaining generic for other VLMs.
+
+Key improvements for LLaVA compatibility:
+- Robust layer path resolution (e.g., "language_model.layers.0" will
+  resolve to "model.language_model.layers.0" when needed)
+- Chat template support (via tokenizer/processor.apply_chat_template)
+- Safer forward-hook handling for tuple outputs
 """
 
 from __future__ import annotations
 
-from typing import Callable, Dict, List, Optional, Sequence, Union
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import logging
 
@@ -28,14 +34,28 @@ class VLM_Wrapper:
         Identifier of the pretrained model on the Hugging Face hub.
     device:
         Torch device onto which the model and inputs will be moved.
+    use_chat_template:
+        If True and available, use the model's chat template for prompt
+        formatting (recommended for LLaVA-family models). If None, this
+        is auto-detected.
+    chat_system_prompt:
+        Optional system prompt to prepend when using chat templates.
     model_kwargs:
         Additional keyword arguments passed to
         :func:`transformers.AutoModelForCausalLM.from_pretrained`.
     """
 
-    def __init__(self, model_name: str, device: str = "cuda", **model_kwargs) -> None:
+    def __init__(
+        self,
+        model_name: str,
+        device: str = "cuda",
+        use_chat_template: Optional[bool] = None,
+        chat_system_prompt: Optional[str] = None,
+        **model_kwargs,
+    ) -> None:
         self.logger = logging.getLogger(__name__)
         self.device = device
+        self.chat_system_prompt = chat_system_prompt
         model_kwargs.setdefault("trust_remote_code", True)
 
         # Load model and accompanying processors/tokenizers.
@@ -43,6 +63,7 @@ class VLM_Wrapper:
             model_name, **model_kwargs
         ).to(device)
 
+        # Processor is preferred for multimodal models
         try:
             self.processor = AutoProcessor.from_pretrained(
                 model_name, trust_remote_code=model_kwargs["trust_remote_code"]
@@ -50,42 +71,103 @@ class VLM_Wrapper:
         except Exception:
             self.processor = None
 
+        # Tokenizer is always required for decoding and text-only fallback
         self.tokenizer = AutoTokenizer.from_pretrained(
             model_name, trust_remote_code=model_kwargs["trust_remote_code"]
+        )
+
+        # Determine chat template availability and usage
+        self._apply_chat_fn = None
+        if self.processor is not None and hasattr(self.processor, "apply_chat_template"):
+            self._apply_chat_fn = self.processor.apply_chat_template  # type: ignore[attr-defined]
+        elif hasattr(self.tokenizer, "apply_chat_template"):
+            self._apply_chat_fn = self.tokenizer.apply_chat_template  # type: ignore[attr-defined]
+
+        self.use_chat_template = (
+            use_chat_template if use_chat_template is not None else self._apply_chat_fn is not None
         )
 
         self.hooks: List[torch.utils.hooks.RemovableHandle] = []
 
     # ------------------------------------------------------------------
-    # Hook management helpers
+    # Module resolution and hook management
     # ------------------------------------------------------------------
-    def _register_hooks(self, layers_to_hook: List[str]) -> Dict[str, torch.Tensor]:
-        """Register forward hooks on the specified layers.
+    def _iter_named_modules(self) -> Iterable[Tuple[str, torch.nn.Module]]:
+        # Include full module tree from the model root
+        yield from self.model.named_modules()
 
-        Returns a dictionary that will be populated with activations during
-        the subsequent forward pass.
+    def list_layers(self, pattern: Optional[str] = None) -> List[str]:
+        """List all submodule paths. Optionally filter by substring pattern."""
+        names = [name for name, _ in self._iter_named_modules()]
+        if pattern:
+            names = [n for n in names if pattern in n]
+        return names
+
+    def _resolve_layer_name(self, layer_spec: str) -> str:
+        """Resolve a possibly shortened layer path to an exact module path.
+
+        Examples
+        --------
+        - "language_model.layers.0" -> "model.language_model.layers.0" (for LLaVA)
+        - If the spec already matches an exact path, it is returned unchanged.
+        - If exactly one module path endswith the spec, that path is returned.
         """
+        # Exact match first
+        for name, _ in self._iter_named_modules():
+            if name == layer_spec:
+                return layer_spec
+
+        # Endswith unique match
+        candidates = [name for name, _ in self._iter_named_modules() if name.endswith(layer_spec)]
+        if len(candidates) == 1:
+            return candidates[0]
+        if len(candidates) > 1:
+            msg = f"Layer spec '{layer_spec}' is ambiguous; candidates: {candidates[:10]}"
+            self.logger.error(msg)
+            raise ValueError(msg)
+
+        # Heuristic prefixes commonly seen in VLMs
+        prefixes = ["model", "base_model.model", "base_model", "transformer", "language_model"]
+        for prefix in prefixes:
+            candidate = f"{prefix}.{layer_spec}" if prefix else layer_spec
+            for name, _ in self._iter_named_modules():
+                if name == candidate:
+                    return candidate
+
+        # As a last resort, raise a helpful error
+        available = [name for name, _ in self._iter_named_modules()]
+        hint = "; e.g., try 'model." + layer_spec + "'" if f"model.{layer_spec}" in ",".join(available) else ""
+        raise ValueError(
+            f"Could not resolve layer spec '{layer_spec}'.{hint} Consider calling list_layers() to inspect available paths."
+        )
+
+    def _register_hooks(self, layers_to_hook: List[str]) -> Dict[str, torch.Tensor]:
+        """Register forward hooks on the specified layers and return a dict that
+        will be populated with activations during the next forward pass."""
 
         activations: Dict[str, torch.Tensor] = {}
         self.hooks = []
 
-        def get_activation_hook(name: str):
+        def get_activation_hook(public_name: str):
             def hook(_module, _inp, output):
-                tensor = output[0] if isinstance(output, tuple) else output
-                activations[name] = tensor.detach()
-
+                # Normalize output to a tensor
+                out = output[0] if isinstance(output, tuple) else output
+                if isinstance(out, torch.Tensor):
+                    activations[public_name] = out.detach()
+                else:
+                    # If the module returns non-tensor (rare), skip recording
+                    self.logger.warning("Hooked module '%s' returned non-tensor output; skipping.", public_name)
             return hook
 
-        for layer_name in layers_to_hook:
-            layer = self.model.get_submodule(layer_name)
-            handle = layer.register_forward_hook(get_activation_hook(layer_name))
+        for spec in layers_to_hook:
+            resolved = self._resolve_layer_name(spec)
+            layer = self.model.get_submodule(resolved)
+            handle = layer.register_forward_hook(get_activation_hook(spec))
             self.hooks.append(handle)
 
         return activations
 
     def _clear_hooks(self) -> None:
-        """Remove all previously registered hooks."""
-
         for handle in self.hooks:
             handle.remove()
         self.hooks = []
@@ -93,23 +175,65 @@ class VLM_Wrapper:
     # ------------------------------------------------------------------
     # Input preparation
     # ------------------------------------------------------------------
+    def _build_chat_texts(
+        self, texts: Sequence[str], images: Optional[Sequence[Optional[Image.Image]]]
+    ) -> Sequence[str]:
+        if not self.use_chat_template or self._apply_chat_fn is None:
+            return texts
+
+        # Build per-sample conversation following HF multimodal schema
+        conversations: List[List[dict]] = []
+        n = len(texts)
+        imgs = list(images) if images is not None else [None] * n
+        if len(imgs) != n:
+            raise ValueError("Number of images must match number of texts when using chat templates.")
+
+        for i in range(n):
+            content: Union[str, List[dict]]
+            if imgs[i] is None:
+                content = texts[i]
+            else:
+                content = [
+                    {"type": "text", "text": texts[i]},
+                    {"type": "image"},
+                ]
+            msgs: List[dict] = []
+            if self.chat_system_prompt:
+                msgs.append({"role": "system", "content": self.chat_system_prompt})
+            msgs.append({"role": "user", "content": content})
+            conversations.append(msgs)
+
+        rendered = self._apply_chat_fn(  # type: ignore[misc]
+            conversations, add_generation_prompt=True, tokenize=False
+        )
+        # HF apply_chat_template may return a single string when given one conv
+        if isinstance(rendered, str):
+            rendered = [rendered]
+        return rendered
+
     def _prepare_inputs(
         self,
         text_prompts: Sequence[str],
         images: Optional[Sequence[Optional[Image.Image]]] = None,
     ) -> Dict[str, torch.Tensor]:
+        texts = list(text_prompts)
+        imgs = list(images) if images is not None else None
+
+        # Prefer processor when available (multimodal-ready)
         if self.processor is not None:
+            # Use chat template if available for models like LLaVA
+            chat_texts = self._build_chat_texts(texts, imgs)
             inputs = self.processor(
-                text=list(text_prompts),
-                images=list(images) if images is not None else None,
+                text=chat_texts,
+                images=imgs,
                 return_tensors="pt",
                 padding=True,
-            ).to(self.device)
-        else:
-            inputs = self.tokenizer(list(text_prompts), return_tensors="pt", padding=True).to(
-                self.device
             )
-        return inputs
+            return inputs.to(self.device)
+
+        # Fallback to tokenizer only (text-only models)
+        inputs = self.tokenizer(texts, return_tensors="pt", padding=True)
+        return inputs.to(self.device)
 
     # ------------------------------------------------------------------
     # Public API
@@ -120,7 +244,16 @@ class VLM_Wrapper:
         images: Optional[Union[Image.Image, Sequence[Optional[Image.Image]]]],
         layers: List[str],
     ) -> Dict[str, torch.Tensor]:
-        """Extract activations from specific layers in batch."""
+        """Extract activations from specific layers in batch.
+
+        Notes
+        -----
+        For LLaVA-style models, typical layer specs include e.g.:
+        - "model.language_model.layers.0"
+        - "model.multi_modal_projector"
+        - "model.vision_tower.vision_model.encoder.layers.0"
+        Shorter forms like "language_model.layers.0" are also accepted.
+        """
 
         if isinstance(text_prompts, str):
             text_prompts = [text_prompts]
@@ -135,7 +268,7 @@ class VLM_Wrapper:
         activations = self._register_hooks(layers)
 
         with torch.no_grad():
-            self.model(**inputs)
+            _ = self.model(**inputs)
 
         self._clear_hooks()
         return activations
@@ -145,7 +278,7 @@ class VLM_Wrapper:
     ) -> str:
         """Generate text from the model without interventions."""
 
-        inputs = self._prepare_inputs(text_prompt, image)
+        inputs = self._prepare_inputs([text_prompt], [image] if image is not None else None)
         with torch.no_grad():
             output_ids = self.model.generate(**inputs, **gen_kwargs)
         return self.tokenizer.decode(output_ids[0], skip_special_tokens=True)
@@ -158,15 +291,30 @@ class VLM_Wrapper:
         image: Optional[Image.Image] = None,
         **gen_kwargs,
     ) -> str:
-        """Generate text while applying a hook-based intervention."""
+        """Generate text while applying a hook-based intervention.
 
-        module = self.model.get_submodule(layer)
+        The intervention function should accept and return a tensor.
+        If the hooked module outputs a tuple, only the first element is
+        modified and the original structure is preserved.
+        """
+
+        resolved = self._resolve_layer_name(layer)
+        module = self.model.get_submodule(resolved)
 
         def hook(_module, _inp, output):
-            return intervention_fn(output)
+            if isinstance(output, tuple):
+                out0 = output[0]
+                if isinstance(out0, torch.Tensor):
+                    new0 = intervention_fn(out0)
+                    # Recreate tuple with modified first element
+                    return (new0,) + output[1:]
+                return output
+            if isinstance(output, torch.Tensor):
+                return intervention_fn(output)
+            return output
 
         handle = module.register_forward_hook(hook)
-        inputs = self._prepare_inputs(text_prompt, image)
+        inputs = self._prepare_inputs([text_prompt], [image] if image is not None else None)
 
         with torch.no_grad():
             output_ids = self.model.generate(**inputs, **gen_kwargs)
@@ -176,4 +324,3 @@ class VLM_Wrapper:
 
 
 __all__ = ["VLM_Wrapper"]
-


### PR DESCRIPTION
Summary
- Add robust support for LLaVA-style models (e.g., LlavaForConditionalGeneration with SigLIP vision tower and Qwen2 language model)
- Keep wrapper generic to work with other VLMs as well

Key changes
- Robust layer path resolution: resolve shortened specs like `language_model.layers.0` to full paths like `model.language_model.layers.0` automatically; handle ambiguity with clear errors; provide list_layers() helper
- Chat template support: use processor/tokenizer `apply_chat_template` when available to format prompts for LLaVA and other HF chat-style VLMs; optional `chat_system_prompt`
- Safer forward-hook handling: normalize tuple outputs and preserve structure during interventions; record activations reliably
- Input prep improvements: prefer AutoProcessor for multimodal models; gracefully fallback to tokenizer-only

Developer notes
- No test changes required; existing tests still pass locally
- Added a .gitignore and removed cached pyc/pytest artifacts from version control

How to use
```python
from src.vlm_wrapper import VLM_Wrapper

wrapper = VLM_Wrapper(
    model_name="YOUR-LLAVA-MODEL",
    device="cuda",
    use_chat_template=True,  # optional; auto-detected when available
)

# List modules to find layers to hook
print(wrapper.list_layers("language_model.layers"))

# Extract activations
acts = wrapper.get_activations(
    ["Describe this image briefly."],
    [Image.open("example.jpg").convert("RGB")],
    ["language_model.layers.0"],  # shortened form resolved automatically
)

# Generate
print(wrapper.generate("Describe the image", Image.open("example.jpg").convert("RGB")))
```

Co-authored-by: openhands <openhands@all-hands.dev>

@h-albert-lee can click here to [continue refining the PR](https://app.all-hands.dev/conversations/25c299ed5e974984b9d1e92ec8499e3f)