### PR TITLE
feat: add configurable image key

### DIFF
--- a/configs/exp1.yaml
+++ b/configs/exp1.yaml
@@ -1,0 +1,19 @@
+model_name: "llava-hf/llava-1.5-7b-hf"
+device: "cuda"
+
+# optional arguments passed to `from_pretrained`
+model_kwargs: {}
+
+extraction_layer: "language_model.layers.0"
+batch_size: 8
+data_sources:
+  toxic_neutral_pairs: "data/general_toxic_neutral_text_pairs.jsonl"
+  intrinsic_toxicity_cases: "data/intrinsic_toxicity_cases.jsonl"
+
+# Use a custom field name for image paths in the dataset
+image_key: "image_file"
+
+intervention_layer: "language_model.layers.0"
+intervention_multiplier: 1.0
+
+output_dir: "results"

--- a/scripts/01_define_intrinsic_toxicity_vector.py
+++ b/scripts/01_define_intrinsic_toxicity_vector.py
@@ -40,7 +40,7 @@ def main() -> None:
     raw = load_jsonl(cfg["data_sources"]["intrinsic_toxicity_cases"])
     data = []
     for item in raw:
-        img = Image.open(item["image_path"]).convert("RGB")
+        img = Image.open(item[cfg.get("image_key", "image_path")]).convert("RGB")
         data.append({"text": item["text"], "image": img})
 
     itv = extractor.compute_itv(data)


### PR DESCRIPTION
## Summary
- allow specifying image field via optional `image_key` config in intrinsic toxicity vector script
- add experiment config example demonstrating custom `image_key`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a69a68cf408320a3b6d1a78655c620