### PR TITLE
Add multi-layer experiment runner and evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ The toolkit also includes a flexible, plugin-based data loading system for custo
    python scripts/04_evaluate_precision_intervention.py --config configs/base_config.yaml
    ```
 
+To scan multiple layers and automatically run precision evaluation on the best one, use:
+   ```bash
+   python scripts/05_run_multi_layer_experiments.py --config configs/base_config.yaml
+   ```
+
 Each script reads model and data settings from the configuration file and writes outputs to the directory specified by `output_dir`.
 
 ## Example configuration
@@ -112,6 +117,8 @@ Each script reads model and data settings from the configuration file and writes
 model_name: "llava-hf/llava-1.5-7b-hf"
 device: "cuda"
 model_kwargs: {}
+layers:
+  - "language_model.layers.0"
 extraction_layer: "language_model.layers.0"
 batch_size: 8
 data_sources:

--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -4,6 +4,10 @@ device: "cuda"
 # optional arguments passed to `from_pretrained`
 model_kwargs: {}
 
+# Layers to evaluate when running multi-layer experiments
+layers:
+  - "language_model.layers.0"
+
 extraction_layer: "language_model.layers.0"
 batch_size: 8
 data_sources:

--- a/doc/README_ko.md
+++ b/doc/README_ko.md
@@ -30,6 +30,7 @@ tests/                    # pytest 단위 테스트
 | `model_name` | 사용하고자 하는 Hugging Face 모델 ID |
 | `device` | 모델을 올릴 디바이스 (`cuda`/`cpu`) |
 | `model_kwargs` | `from_pretrained` 에 전달할 추가 인자 |
+| `layers` | 여러 레이어를 순회하며 평가할 레이어 목록 |
 | `extraction_layer` | 활성화를 추출할 레이어 이름 |
 | `batch_size` | `VectorExtractor` 가 한 번에 처리할 배치 크기 |
 | `data_sources.toxic_neutral_pairs` | 일반 독성 벡터 계산용 텍스트 페어 파일 |
@@ -63,6 +64,8 @@ tests/                    # pytest 단위 테스트
    - GTV와 ITV의 코사인 유사도를 계산하여 두 벡터의 관계를 분석합니다.
 4. **`04_evaluate_precision_intervention.py`**
    - 독성 분류기를 이용해 개입 전후의 텍스트 독성 점수를 비교합니다.
+5. **`05_run_multi_layer_experiments.py`**
+   - 여러 레이어를 순회하며 유사도를 기록하고 가장 높은 레이어에 대해 정밀 개입 평가를 수행합니다.
 
 ## 6. 배치 처리와 성능
 

--- a/scripts/04_evaluate_precision_intervention.py
+++ b/scripts/04_evaluate_precision_intervention.py
@@ -35,6 +35,7 @@ def main() -> None:
 
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
+    logger.info("정밀 개입 평가를 시작합니다...")
 
     wrapper = VLM_Wrapper(cfg["model_name"], device=cfg.get("device", "cuda"), **cfg.get("model_kwargs", {}))
     layer = cfg["intervention_layer"]

--- a/scripts/05_run_multi_layer_experiments.py
+++ b/scripts/05_run_multi_layer_experiments.py
@@ -1,0 +1,94 @@
+"""Run toxicity vector analysis across multiple layers and evaluate the best."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+import yaml
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run multi-layer experiments")
+    parser.add_argument("--config", type=str, default="configs/base_config.yaml")
+    return parser.parse_args()
+
+
+def run_script(script: str, config_path: Path) -> None:
+    subprocess.run([
+        "python",
+        script,
+        "--config",
+        str(config_path),
+    ], check=True)
+
+
+def main() -> None:
+    args = parse_args()
+    with open(args.config, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    layers = cfg.get("layers", [cfg["extraction_layer"]])
+    base_out_dir = Path(cfg["output_dir"])
+    base_out_dir.mkdir(parents=True, exist_ok=True)
+
+    results = []
+
+    for layer in layers:
+        logger.info("Processing layer %s", layer)
+        layer_cfg = deepcopy(cfg)
+        layer_cfg["extraction_layer"] = layer
+        layer_cfg["intervention_layer"] = layer
+        layer_dir = base_out_dir / layer.replace(".", "_")
+        layer_dir.mkdir(parents=True, exist_ok=True)
+        layer_cfg["output_dir"] = str(layer_dir)
+        temp_cfg_path = layer_dir / "config.yaml"
+        with open(temp_cfg_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(layer_cfg, f)
+
+        run_script("scripts/00_define_general_toxicity_vector.py", temp_cfg_path)
+        run_script("scripts/01_define_intrinsic_toxicity_vector.py", temp_cfg_path)
+
+        gtv = torch.load(layer_dir / "general_toxicity_vector.pt")
+        itv = torch.load(layer_dir / "intrinsic_toxicity_vector.pt")
+        sim = F.cosine_similarity(gtv.flatten(), itv.flatten(), dim=0).item()
+        results.append({"layer": layer, "cosine_similarity": sim})
+        logger.info("Layer %s cosine similarity %.4f", layer, sim)
+
+    result_path = base_out_dir / "layer_cosine_results.csv"
+    with open(result_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["layer", "cosine_similarity"])
+        writer.writeheader()
+        writer.writerows(results)
+    logger.info("Saved results to %s", result_path)
+
+    best = max(results, key=lambda x: x["cosine_similarity"])
+    logger.info(
+        "Best layer %s with cosine similarity %.4f",
+        best["layer"],
+        best["cosine_similarity"],
+    )
+
+    best_cfg = deepcopy(cfg)
+    best_layer_dir = base_out_dir / best["layer"].replace(".", "_")
+    best_cfg["intervention_layer"] = best["layer"]
+    best_cfg["output_dir"] = str(best_layer_dir)
+    best_cfg_path = best_layer_dir / "best_config.yaml"
+    with open(best_cfg_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(best_cfg, f)
+
+    logger.info("정밀 개입 평가를 시작합니다...")
+    run_script("scripts/04_evaluate_precision_intervention.py", best_cfg_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/feature_extractor.py
+++ b/src/feature_extractor.py
@@ -42,16 +42,7 @@ class VectorExtractor:
             toxic_act = self.wrapper.get_activations(t_batch, None, [self.layer])[self.layer]
             neutral_act = self.wrapper.get_activations(n_batch, None, [self.layer])[self.layer]
             
-            # --- 🔥 여기부터 수정 시작 🔥 ---
-
-            # 각 텐서의 시퀀스 길이 차원(dim=1)에 대해 평균을 계산합니다.
-            toxic_act_mean = toxic_act.mean(dim=1)
-            neutral_act_mean = neutral_act.mean(dim=1)
-
-            # 평균을 낸 벡터들로 차이를 계산합니다.
-            diffs.append(toxic_act_mean - neutral_act_mean)
-            
-            # --- 🔥 여기까지 수정 끝 🔥 ---
+            diffs.append(toxic_act - neutral_act)
 
             self.logger.debug("Processed GTV batch %d-%d", i, i + len(t_batch))
 
@@ -82,17 +73,7 @@ class VectorExtractor:
             image_act = self.wrapper.get_activations(["" for _ in images], images, [self.layer])[self.layer]
             fused_act = self.wrapper.get_activations(texts, images, [self.layer])[self.layer]
 
-            # --- 🔥 여기부터 수정 시작 🔥 ---
-
-            # 각 텐서의 시퀀스 길이 차원(dim=1)에 대해 평균을 계산합니다.
-            text_act_mean = text_act.mean(dim=1)
-            image_act_mean = image_act.mean(dim=1)
-            fused_act_mean = fused_act.mean(dim=1)
-
-            # 평균을 낸 벡터들로 연산을 수행합니다.
-            residuals.append(fused_act_mean - (text_act_mean + image_act_mean))
-
-            # --- 🔥 여기까지 수정 끝 🔥 ---
+            residuals.append(fused_act - (text_act + image_act))
             
             self.logger.debug("Processed ITV batch %d-%d", i, i + len(batch))
 

--- a/src/feature_extractor.py
+++ b/src/feature_extractor.py
@@ -41,8 +41,14 @@ class VectorExtractor:
             n_batch = neutral_texts[i : i + self.batch_size]
             toxic_act = self.wrapper.get_activations(t_batch, None, [self.layer])[self.layer]
             neutral_act = self.wrapper.get_activations(n_batch, None, [self.layer])[self.layer]
-            
-            diffs.append(toxic_act - neutral_act)
+
+
+            # 각 텐서의 시퀀스 길이 차원(dim=1)에 대해 평균을 계산합니다.
+            toxic_act_mean = toxic_act.mean(dim=1)
+            neutral_act_mean = neutral_act.mean(dim=1)
+
+            # 평균을 낸 벡터들로 차이를 계산합니다.
+            diffs.append(toxic_act_mean - neutral_act_mean)
 
             self.logger.debug("Processed GTV batch %d-%d", i, i + len(t_batch))
 
@@ -73,7 +79,13 @@ class VectorExtractor:
             image_act = self.wrapper.get_activations(["" for _ in images], images, [self.layer])[self.layer]
             fused_act = self.wrapper.get_activations(texts, images, [self.layer])[self.layer]
 
-            residuals.append(fused_act - (text_act + image_act))
+            # 각 텐서의 시퀀스 길이 차원(dim=1)에 대해 평균을 계산합니다.
+            text_act_mean = text_act.mean(dim=1)
+            image_act_mean = image_act.mean(dim=1)
+            fused_act_mean = fused_act.mean(dim=1)
+
+            # 평균을 낸 벡터들로 연산을 수행합니다.
+            residuals.append(fused_act_mean - (text_act_mean + image_act_mean))
             
             self.logger.debug("Processed ITV batch %d-%d", i, i + len(batch))
 


### PR DESCRIPTION
## Summary
- support specifying multiple layers in config
- add runner script to iterate layers, record cosine similarities, and evaluate the best
- log precision evaluation start and fix vector extraction utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6fe119dd483208540d934fb802d45